### PR TITLE
Multiple request body params

### DIFF
--- a/main.py
+++ b/main.py
@@ -237,7 +237,7 @@ async def read_numeric_items(
 # of query parameters, FastAPI would interpret them as request body parameters
 
 
-class LibUser(BaseModel):
+class LibUser(str, Enum):
     student = "student"
     teacher = "teacher"
 


### PR DESCRIPTION
### Recap[¶](https://fastapi.tiangolo.com/tutorial/body-multiple-params/#recap)

You can add multiple body parameters to your path operation function, even though a request can only have a single body.

You can also declare singular values to be received as part of the body.

And you can instruct FastAPI to embed the body in a key even when there is only a single parameter declared.